### PR TITLE
Added a support for MLST

### DIFF
--- a/srst2_table_from_assemblies_slurm.py
+++ b/srst2_table_from_assemblies_slurm.py
@@ -78,6 +78,8 @@ def main():
             cmd += ' --max_divergence ' + str(args.max_divergence)
         if args.algorithm:
             cmd += ' --algorithm ' + args.algorithm
+        if args.mlst:
+            cmd += ' --mlst'
 
         if args.report_new_consensus:
             new_consensus_path, new_consensus_name = os.path.split(args.report_new_consensus)
@@ -113,6 +115,7 @@ def get_arguments():
     parser.add_argument('--report_new_consensus', type=str, required=False, help='When matching alleles are not found, report the found alleles in this file (will be combined with assembly identifiers)')
     parser.add_argument('--report_all_consensus', type=str, required=False, help='Report all found alleles in this file (will be combined with assembly identifiers)')
     parser.add_argument('--algorithm', action="store", help="blast algorithm (blastn)")
+    parser.add_argument('--mlst', action='store_true', required=False, help="Turn it on to find MLST genes")
     return parser.parse_args()
 
 


### PR DESCRIPTION
This pull request aims to add a support for MLST.

I have written a script to format an MLST database as per the format for genotyping in SRST2: https://github.com/wanyuac/SRST2_toolkit/blob/master/format_mlst_db.py. An example of final sequence IDs is:

> 0__gapA__2__2

The MLST profile of each sample looks like:
Sample  gapA    infB    mdh pgi phoE    rpoB    tonB
1084    2   1   1   1   9   4   12

A pipeline for generating the aforementioned results:
cat _.fas | python format_mlst_db.py > alleles_srst2Formatted.fna
python srst2_table_from_assemblies_slurm.py --script srst2_table_from_assemblies.py --assemblies merged_ref/_.fasta --gene_db alleles_srst2Formatted.fna --output kp --report_all_consensus all_consensus.fna --report_new_consensus new_consensus.fna --mlst > blast_mlst.log

I think it may be useful for other users.
